### PR TITLE
use nodejs 4 via nvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 2.7
 sudo: false
 before_install:
+    - nvm install 4
     - pip install -r requirements.txt
     - pip install pytest
     - pip install pytest-cov


### PR DESCRIPTION
Travis has old 0.10, which the build tools from jupyterlab apparently don't like
